### PR TITLE
feat: Toggleable adaptive film grain

### DIFF
--- a/Docs/Parameters.md
+++ b/Docs/Parameters.md
@@ -81,6 +81,7 @@ For more information on valid values for specific keys, refer to the [EbEncSetti
 | **Sharpness**                    | --sharpness                 | [-7-7]                         | 1           | Bias towards block sharpness in rate-distortion optimization of transform coefficients                                                                               |
 | **Max32TxSize**                  | --max-32-tx-size            | [0-1]                          | 0           | Restricts use of block transform sizes to a maximum of 32x32 pixels (disabled: use max of 64x64 pixels)      |
 | **NoiseNormStrength**            |  --noise-norm-strength      | [0-4]                          | 0           | Selectively boost AC coefficients to improve fine detail retention in certain circumstances                  |
+| **AdaptiveFilmGrain**            | --adaptive-film-grain       | [0,1]                          | 1           | Allows film grain synthesis to be sourced from different block sizes depending on resolution                  |
 
 ## Rate Control Options
 

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -1050,8 +1050,18 @@ typedef struct EbSvtAv1EncConfiguration {
      * Default is true in SVT-AV1-HDR. */
      bool alt_lambda_factors;
 
+     /**
+     * @brief Toggle default film grain blocksize behavior
+     * 0: use default blocksize behavior (32x32)
+     * 1: use adaptive blocksize based on resolution
+     *  - 8x8 for <4k
+     *  - 16x16 for 4k
+     * Default is 1
+     */
+     bool adaptive_film_grain;
+
     /*Add 128 Byte Padding to Struct to avoid changing the size of the public configuration struct*/
-    uint8_t padding[128 - (sizeof(uint8_t) * 9) - (sizeof(double) * 2) - (sizeof(bool) * 2)
+    uint8_t padding[128 - (sizeof(uint8_t) * 9) - (sizeof(double) * 2) - (sizeof(bool) * 3)
         - sizeof(bool)
     ];
 } EbSvtAv1EncConfiguration;

--- a/Source/App/app_config.c
+++ b/Source/App/app_config.c
@@ -211,6 +211,8 @@
 
 #define MAX_32_TX_SIZE_TOKEN "--max-32-tx-size"
 
+#define ADAPTIVE_FILM_GRAIN_TOKEN "--adaptive-film-grain"
+
 #define NOISE_NORM_STRENGTH_TOKEN "--noise-norm-strength"
 #define KF_TF_STRENGTH_FILTER_TOKEN "--kf-tf-strength"
 
@@ -1007,6 +1009,8 @@ ConfigDescription config_entry_variance_boost[] = {
     {MAX_32_TX_SIZE_TOKEN, "[PSY] Limits the allowed transform sizes to a maximum of 32x32, default is 0 [0-1]"},
     // Noise normalization strength
     {NOISE_NORM_STRENGTH_TOKEN, "[PSY] Noise normalization strength, default is 1; recommended value for tune 3 is 3 [0-4]"},
+    // Adaptive film grain
+    {SINGLE_INPUT, ADAPTIVE_FILM_GRAIN_TOKEN, "[PSY] Adapts film grain blocksize based on video resolution, default is 1 [0-1]", set_cfg_generic_token},
     //Alt-ref temporal filtering strength on keyframes
     {KF_TF_STRENGTH_FILTER_TOKEN, "[PSY] Adjust alt-ref TF strength on keyframes, default is 1 (4x weaker than mainline) [0-4]"},
     //AC-Bias
@@ -1229,6 +1233,9 @@ ConfigEntry config_entry[] = {
 
     // Max 32 tx size
     {MAX_32_TX_SIZE_TOKEN, "Max32TxSize", set_cfg_generic_token},
+
+    // Adaptive film grain
+    {SINGLE_INPUT, ADAPTIVE_FILM_GRAIN_TOKEN, "AdaptiveFilmGrain", set_cfg_generic_token},
 
     // Noise normalization strength
     {NOISE_NORM_STRENGTH_TOKEN, "NoiseNormStrength", set_cfg_generic_token},

--- a/Source/Lib/Codec/noise_model.c
+++ b/Source/Lib/Codec/noise_model.c
@@ -2126,10 +2126,12 @@ EbErrorType svt_aom_denoise_and_model_ctor(AomDenoiseAndModel *object_ptr, EbPtr
     svt_aom_derive_input_resolution(&input_resolution, input_size);
 
     int32_t denoise_block_size = 32;
-    if (input_resolution <= INPUT_SIZE_1080p_RANGE)
-        denoise_block_size = 8;
-    else if (input_resolution <= INPUT_SIZE_4K_RANGE)
-        denoise_block_size = 16;
+    if (init_data_ptr->adaptive_film_grain) {
+        if (input_resolution <= INPUT_SIZE_1080p_RANGE)
+            denoise_block_size = 8;
+        else if (input_resolution <= INPUT_SIZE_4K_RANGE)
+            denoise_block_size = 16;
+    }
 
     object_ptr->block_size  = denoise_block_size;
     object_ptr->noise_level = (float)(init_data_ptr->noise_level / 10.0);

--- a/Source/Lib/Codec/noise_model.h
+++ b/Source/Lib/Codec/noise_model.h
@@ -207,6 +207,7 @@ typedef struct DenoiseAndModelInitData {
     uint16_t stride_cb;
     uint16_t stride_cr;
     uint8_t  denoise_apply;
+    bool     adaptive_film_grain;
 } DenoiseAndModelInitData;
 
 typedef struct AomDenoiseAndModel {

--- a/Source/Lib/Codec/pcs.h
+++ b/Source/Lib/Codec/pcs.h
@@ -1193,6 +1193,7 @@ typedef struct PictureControlSetInitData {
     bool    allintra;
     double  qp_scale_compress_strength;
     bool    max_32_tx_size;
+    bool    adaptive_film_grain;
     uint8_t noise_norm_strength;
     uint8_t kf_tf_strength;
     double  ac_bias;

--- a/Source/Lib/Codec/pic_analysis_process.c
+++ b/Source/Lib/Codec/pic_analysis_process.c
@@ -1159,6 +1159,7 @@ static int32_t apply_denoise_2d(SequenceControlSet *scs, PictureParentControlSet
     fg_init_data.stride_cb            = pcs->enhanced_pic->stride_cb;
     fg_init_data.stride_cr            = pcs->enhanced_pic->stride_cr;
     fg_init_data.denoise_apply        = scs->static_config.film_grain_denoise_apply;
+    fg_init_data.adaptive_film_grain  = scs->static_config.adaptive_film_grain;
     EB_NEW(denoise_and_model, svt_aom_denoise_and_model_ctor, (EbPtr)&fg_init_data);
 
     if (svt_aom_denoise_and_model_run(denoise_and_model,

--- a/Source/Lib/Globals/enc_handle.c
+++ b/Source/Lib/Globals/enc_handle.c
@@ -1527,6 +1527,7 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
         input_data.tf_strength = enc_handle_ptr->scs_instance_array[instance_index]->scs->static_config.tf_strength;
         input_data.qp_scale_compress_strength = enc_handle_ptr->scs_instance_array[instance_index]->scs->static_config.qp_scale_compress_strength;
         input_data.max_32_tx_size = enc_handle_ptr->scs_instance_array[instance_index]->scs->static_config.max_32_tx_size;
+        input_data.adaptive_film_grain = enc_handle_ptr->scs_instance_array[instance_index]->scs->static_config.adaptive_film_grain;
         input_data.noise_norm_strength = enc_handle_ptr->scs_instance_array[instance_index]->scs->static_config.noise_norm_strength;
         input_data.kf_tf_strength = enc_handle_ptr->scs_instance_array[instance_index]->scs->static_config.kf_tf_strength;
         input_data.ac_bias = enc_handle_ptr->scs_instance_array[instance_index]->scs->static_config.ac_bias;
@@ -4655,6 +4656,10 @@ static void copy_api_from_app(
 
     // Max 32 TX size
     scs->static_config.max_32_tx_size = config_struct->max_32_tx_size;
+
+    // Adaptive film grain
+    scs->static_config.adaptive_film_grain = config_struct->adaptive_film_grain;
+
     // Noise normalization strength
     scs->static_config.noise_norm_strength = config_struct->noise_norm_strength;
     //Alt-ref keyframe temporal filtering strength

--- a/Source/Lib/Globals/enc_settings.c
+++ b/Source/Lib/Globals/enc_settings.c
@@ -1102,6 +1102,7 @@ EbErrorType svt_av1_set_default_params(EbSvtAv1EncConfiguration *config_ptr) {
     config_ptr->extended_crf_qindex_offset        = 0;
     config_ptr->qp_scale_compress_strength        = 1;
     config_ptr->max_32_tx_size                    = false;
+    config_ptr->adaptive_film_grain               = true;
     config_ptr->noise_norm_strength               = 1;
     config_ptr->kf_tf_strength                    = 1;
     config_ptr->ac_bias                           = 1.0;
@@ -1229,10 +1230,17 @@ void svt_av1_print_lib_params(SequenceControlSet *scs) {
         }
 
         if (config->film_grain_denoise_strength != 0) {
-            SVT_INFO("SVT [config]: film grain synth / denoising / level \t\t\t\t: %d / %d / %d\n",
-                     1,
-                     config->film_grain_denoise_apply,
-                     config->film_grain_denoise_strength);
+            if (config->adaptive_film_grain) {
+                SVT_INFO("SVT [config]: film grain synth / denoising / level / adaptive blocksize \t: %d / %d / %d / True\n",
+                         1,
+                         config->film_grain_denoise_apply,
+                         config->film_grain_denoise_strength);
+            } else {
+                SVT_INFO("SVT [config]: film grain synth / denoising / level / adaptive blocksize \t: %d / %d / %d / False\n",
+                         1,
+                         config->film_grain_denoise_apply,
+                         config->film_grain_denoise_strength);
+            }
         }
         SVT_INFO("SVT [config]: sharpness / luminance-based QP bias \t\t\t\t: %d / %d\n",
                  config->sharpness,
@@ -2261,6 +2269,7 @@ EB_API EbErrorType svt_av1_enc_parse_parameter(EbSvtAv1EncConfiguration *config_
         {"avif", &config_struct->avif},
         {"rtc", &config_struct->rtc},
         {"max-32-tx-size", &config_struct->max_32_tx_size},
+        {"adaptive-film-grain", &config_struct->adaptive_film_grain},
         {"alt-lambda-factors", &config_struct->alt_lambda_factors},
     };
     const size_t bool_opts_size = sizeof(bool_opts) / sizeof(bool_opts[0]);


### PR DESCRIPTION
On the AV1 weeb discord, it was found to create patches without grain (though it was on svt-av1-psyex, but it shouldn't be different on svt-av1-hdr), and on the AV1 Community discord there was mention of flickering grain