### PR TITLE
fix ETA and size estimation ending too soon in --progress 3 output

### DIFF
--- a/Source/App/app_process_cmd.c
+++ b/Source/App/app_process_cmd.c
@@ -956,13 +956,13 @@ void process_output_stream_buffer(EncChannel *channel, EncApp *enc_app, int32_t 
             int ete_hours           = ete_r / 3600;
             int ete_minutes         = (ete_r - (ete_hours * 3600)) / 60;
             int ete_seconds         = ete_r - (ete_hours * 3600) - (ete_minutes * 60);
-            const double eta        = (app_cfg->performance_context.total_encode_time / app_cfg->frames_encoded) * (app_cfg->frames_to_be_encoded - app_cfg->frames_encoded);
+            const double eta        = (app_cfg->frames_to_be_encoded - *frame_count) / fps;
             int eta_r               = round(eta);
             int eta_hours           = eta_r / 3600;
             int eta_minutes         = (eta_r - (eta_hours * 3600)) / 60;
             int eta_seconds         = eta_r - (eta_hours * 3600) - (eta_minutes * 60);
-            double size             = ((double)app_cfg->performance_context.byte_count / 1000000);
-            double estsz            = ((double)app_cfg->performance_context.byte_count * app_cfg->frames_to_be_encoded / (app_cfg->frames_encoded * 1000) / 1000);
+            const double size       = ((double)app_cfg->performance_context.byte_count / 1000000);
+            const double estsz      = size / *frame_count * app_cfg->frames_to_be_encoded;
 
             switch (app_cfg->progress) {
             case 0: break;


### PR DESCRIPTION
Remaining time and final size estimation currently ends too soon, which for short clips results in `-0:00:00` ETA and estimated size being equal to current size:
```powershell
PS Z:\> .\SvtAv1EncApp.exe --input .\collateral.y4m --preset 1 --progress 3
Svt[info]: -------------------------------------------
Svt[info]: SVT [version]:       SVT-AV1-HDR Encoder Lib v3.1.0-17-gb6d2a47e
Svt[info]: SVT [build]  :       Clang 21.1.1     64 bit
Svt[info]: LIB Build date: Sep 27 2025 22:05:11
Svt[info]: -------------------------------------------
Svt[info]: Level of Parallelism: 5
Svt[info]: Number of PPCS 140
Svt[info]: [asm level on system : up to avx2]
Svt[info]: [asm level selected : up to avx2]
Svt[info]: -------------------------------------------
Svt[info]: SVT [config]: main profile   tier (auto)     level (auto)
Svt[info]: SVT [config]: width / height / fps numerator / fps denominator               : 1920 / 800 / 24000 / 1001
Svt[info]: SVT [config]: bit-depth / color format                                       : 10 / YUV420
Svt[info]: SVT [config]: preset / tune / pred struct                                    : 1 / PSNR / random access
Svt[info]: SVT [config]: gop size / mini-gop size / key-frame type                      : 321 / 32 / key frame
Svt[info]: SVT [config]: BRC mode / rate factor                                         : CRF / 35.00
Svt[info]: SVT [config]: AQ mode / Variance Boost strength / octile / curve             : 2 / 2 / 5 / 0
Svt[info]: SVT [config]: sharpness / luminance-based QP bias                            : 1 / 0
Svt[info]: SVT [config]: temporal filtering strength                                    : 1
Svt[info]: SVT [config]: QP scale compress strength                                     : 1.00
Svt[info]: SVT [config]: Noise Normalization Strength                                   : 1
Svt[info]: SVT [config]: Keyframe TF Strength                                           : 1
Svt[info]: SVT [config]: AC Bias Strength                                               : 1.00
Svt[info]: SVT [config]: spy-rd                                                         : non
Svt[info]: -------------------------------------------
Encoding:    9/49 Frames @ 36.31 fpm | 1402.59 kb/s | Time: 0:00:15 [-0:00:00] | Size: 0.36 MB [0.36 MB]
```
With this commit the ETA and size estimation don't end too soon:
```powershell
PS Z:\> .\SvtAv1EncApp_fix.exe --input .\collateral.y4m --preset 1 --progress 3
Svt[info]: -------------------------------------------
Svt[info]: SVT [version]:       SVT-AV1-HDR Encoder Lib v3.1.0-17-gb6d2a47e-dirty
Svt[info]: SVT [build]  :       Clang 21.1.1     64 bit
Svt[info]: LIB Build date: Sep 27 2025 23:42:32
Svt[info]: -------------------------------------------
Svt[info]: Level of Parallelism: 5
Svt[info]: Number of PPCS 140
Svt[info]: [asm level on system : up to avx2]
Svt[info]: [asm level selected : up to avx2]
Svt[info]: -------------------------------------------
Svt[info]: SVT [config]: main profile   tier (auto)     level (auto)
Svt[info]: SVT [config]: width / height / fps numerator / fps denominator               : 1920 / 800 / 24000 / 1001
Svt[info]: SVT [config]: bit-depth / color format                                       : 10 / YUV420
Svt[info]: SVT [config]: preset / tune / pred struct                                    : 1 / PSNR / random access
Svt[info]: SVT [config]: gop size / mini-gop size / key-frame type                      : 321 / 32 / key frame
Svt[info]: SVT [config]: BRC mode / rate factor                                         : CRF / 35.00
Svt[info]: SVT [config]: AQ mode / Variance Boost strength / octile / curve             : 2 / 2 / 5 / 0
Svt[info]: SVT [config]: sharpness / luminance-based QP bias                            : 1 / 0
Svt[info]: SVT [config]: temporal filtering strength                                    : 1
Svt[info]: SVT [config]: QP scale compress strength                                     : 1.00
Svt[info]: SVT [config]: Noise Normalization Strength                                   : 1
Svt[info]: SVT [config]: Keyframe TF Strength                                           : 1
Svt[info]: SVT [config]: AC Bias Strength                                               : 1.00
Svt[info]: SVT [config]: spy-rd                                                         : non
Svt[info]: -------------------------------------------
Encoding:    9/49 Frames @ 36.78 fpm | 1402.59 kb/s | Time: 0:00:15 [-0:01:05] | Size: 0.36 MB [1.95 MB]
```