### PR TITLE
translate spy-rd cli output and combine with ac bias

### DIFF
--- a/Source/Lib/Globals/enc_settings.c
+++ b/Source/Lib/Globals/enc_settings.c
@@ -1266,12 +1266,11 @@ void svt_av1_print_lib_params(SequenceControlSet *scs) {
         }
 
         if (config->ac_bias > 0.0) {
-            SVT_INFO("SVT [config]: AC Bias Strength \t\t\t\t\t\t: %.2f\n",
-                    config->ac_bias);
+            SVT_INFO("SVT [config]: AC Bias Strength / SPY-RD \t\t\t\t\t: %.2f / %s\n",
+                     config->ac_bias,
+                     // 1 is full spy-rd, 2 is partial spy-rd
+                     config->spy_rd == 1 ? "full" : (config->spy_rd == 2 ? "partial" : "off"));
         }
-        // 1 is full spy-rd, 2 is partial spy-rd
-        SVT_INFO("SVT [config]: spy-rd \t\t\t\t\t\t\t: %s\n",
-        config->spy_rd == 1 ? "oui" : (config->spy_rd == 2 ? "ouais" : "non"));
     }
 #if DEBUG_BUFFERS
     SVT_INFO("SVT [config]: INPUT / OUTPUT \t\t\t\t\t\t\t: %d / %d\n",


### PR DESCRIPTION
Since SPY-RD only applies when AC Bias is enabled, it should probably be shown in CLI output only when AC Bias is enabled.