### PR TITLE
fix: HBD mode decision now starting at P4 for high visual gains

### DIFF
--- a/Source/Lib/Codec/enc_mode_config.c
+++ b/Source/Lib/Codec/enc_mode_config.c
@@ -1866,9 +1866,16 @@ void svt_aom_sig_deriv_multi_processes(SequenceControlSet *scs, PictureParentCon
     if (pcs->scs->static_config.hbd_mds > 0)
         pcs->hbd_md = pcs->scs->static_config.hbd_mds;
     else if (scs->enable_hbd_mode_decision == DEFAULT)
-        if (enc_mode <= ENC_M2)
+        //In svt-av1-hdr, high bit depth mode decisions are enabled by default
+        //starting from Preset 4 due to the high visual gains 10-bit MD provide
+        //This is worth the computational tradeoff from HBD MD and light PD0 being
+        //essentially disabled with HBD MD
+        if (enc_mode <= ENC_M4)
             pcs->hbd_md = 1;
+        //Preset 5 also deserves some love
         else if (enc_mode <= ENC_M5)
+            pcs->hbd_md = 2;
+        else if (enc_mode <= ENC_M6)
             pcs->hbd_md = is_base ? 2 : 0;
         else
             pcs->hbd_md = is_islice ? 2 : 0;


### PR DESCRIPTION
This is a decision that has been a long time coming.

We've decided to somewhat mirror svt-av1-essential in this regard, but not to such an extreme.

So, for Preset 4 onwards, this enables HBD-MD (10-bit MD) for higher visual quality and higher coding efficiency overall.

I've also made Preset 4 slightly better by fully enabling hybrid 8/10b mode decision, and P6 gets hybrid 8/10b mode decision on base hierarchical frames.