### PR TITLE
[Perf] Improve build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,11 @@ endif()
 
 # Always build with -fPIC
 set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
-set(CMAKE_C_STANDARD 23)
+if(WIN32)
+    set(CMAKE_C_STANDARD 17)
+else()
+    set(CMAKE_C_STANDARD 23)
+endif()
 set(CMAKE_CXX_STANDARD 23)
 
 # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to


### PR DESCRIPTION
These are `CMakeLists.txt` changes aiming to improve convenience and performance.

- Comment-out `MINIMAL_BUILD` related logic:

Previously svt-av1 used different types of allocations (allocated the highest possible without `MINIMAL_BUILD` and resolution-based dynamic allocation with `MINIMAL_BUILD`). Currently the related codepath is completely removed. So this is dead code.

Now it allocates based on superblocks: `scs->max_block_cnt = 2377;` and `scs->max_block_cnt = 4421;` and should be similar to previous MINIMAL_BUILD in terms of performance.

- Disable `-fPIC` by default

This is unnecessary unless specifically needed. Disabling position independent code can improve performance due to several reasons (No GOT indirection, simpler addressing) but it weakens ASLR (security). Unless security is a huge priority, this can be safely disabled.

- Use modern C/C++ standards

I have been testing this for a long time, and the code could always be compiled without issues using C/C++ 23 instead of C99. 

- Disable `-z noexecstack -z relro`

These are security features. They make stack non-executable (prevents stack-based exploits) and Relocation Read-Only mode is for GOT hardening. In reality, these types of exploits are extremely unlikely for SVT-AV1-HDR users. Again, if needed, these should be manually added.

- Remove `FORTIFY_SOURCE` by default 

Again, a security feature that adds runtime buffer overflow detection that could be added manually when needed.

- Removes assembly debug symbol generation by default

Can be manually added, if needed.

- Fix a bug for PGO builds:

```cmake
-set(PROFILE_MERGE_CMD sh -c "${LLVM_PROFDATA} merge --sparse=true *.profraw -o default.profdata")
+set(PROFILE_MERGE_CMD sh -c "cd ${SVT_AV1_PGO_DIR} && ${LLVM_PROFDATA} merge --sparse=true *.profraw -o default.profdata")
```

Currently the build system has a variable: `pgo-dir=/path/to/profiles`

But it does nothing because it looks at the current directory. On the other hand, automated pgo path uses an unrealistic video and 8bit encoding. It's best for users to use their own profiles.

With this change, the user can indicate their profile folder for the build system to use:
```sh
./build.sh ... enable-pgo pgo-compile-use pgo-dir=/path/to/profiles
```