### PR TITLE
fix: making sharp-tx work on every single tune, not just tune VQ/VQ-SSIM (alt-ssim-tuning)

### DIFF
--- a/Source/Lib/Codec/full_loop.c
+++ b/Source/Lib/Codec/full_loop.c
@@ -1062,7 +1062,9 @@ static void svt_av1_optimize_b(PictureControlSet *pcs, ModeDecisionContext *ctx,
     int           rweight       = 100;
     const int32_t sharpness_val = CLIP3(0, 7, pcs->scs->static_config.sharpness);
     const int     rshift        = MAX(2, (int)sharpness_val);
-    if (use_sharpness && delta_q_present && plane == 0) {
+    //sharp-tx is now available on every tune
+    //including tune PSNR and SSIM derived based tunes
+    if ((use_sharpness || pcs->scs->static_config.sharp_tx == 1) && delta_q_present && plane == 0) {
         int diff = ctx->sb_ptr->qindex - quantizer_to_qindex[picture_qp];
         //Only activate on 2 conditions: diff<0
         //or if the user controlled sharp-tx is active


### PR DESCRIPTION
Title is content of the patch.

In essence, when testing svt-av1-psy 3.0.2, I wanted to add sharp-tx to every tune after seeing how beneficial it was to almost every tune.

However, I had completely forgotten to enable this either in the last svt-av1-psy merge or even svt-av1-psyex...

This should be good to merge now and was written in a form that preserves mainline behavior when `--sharp-tx 0` is set.