### PR TITLE
Fix chroma blur issue with restoration at preset <= 3

### DIFF
--- a/Source/Lib/Codec/enc_mode_config.c
+++ b/Source/Lib/Codec/enc_mode_config.c
@@ -1364,7 +1364,7 @@ static uint8_t svt_aom_get_wn_filter_level(EncMode enc_mode, uint8_t input_resol
             wn_filter_lvl = 5;
         else
             wn_filter_lvl = 0;
-    } else if (enc_mode <= ENC_M3 && !rtc_tune)
+    } else if (enc_mode <= ENC_M3)
         wn_filter_lvl = is_not_last_layer ? 4 : 0;
     else if ((enc_mode <= ENC_M8 && !rtc_tune) || (enc_mode <= ENC_M6 && rtc_tune))
         wn_filter_lvl = is_not_last_layer ? 5 : 0;


### PR DESCRIPTION
Seems to be related to the wiener filter not using chroma at the configured level, unsure as to the reason why the enabling of the self-guided filter at preset 3 causes the issue, but this does work as a fix :)

For visual example, a comparison of the current state vs with this PR:
<img width="1920" height="1080" alt="Previous" src="https://github.com/user-attachments/assets/dbdd6840-0a7e-44eb-b02e-fe9c26c44b37" />
<img width="1920" height="1080" alt="WithPR" src="https://github.com/user-attachments/assets/ef38b885-cb45-45ab-bde8-73ccd83a388a" />
