### PR TITLE
Move libdovi, libhdr10plus, and fgs-table to the library side

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -1096,6 +1096,21 @@ typedef struct EbSvtAv1EncConfiguration {
      */
     bool color_range_provided;
 
+    /**
+     * @brief Path to Dolby Vision RPU file.
+     */
+    char *dovi_rpu_file;
+    
+    /**
+     * @brief Path to HDR10+ metadata JSON file.
+     */
+    char *hdr10plus_json_file;
+
+    /**
+     * @brief Path to film grain table file.
+     */
+    char *fgs_table_file;
+
     /*Add 128 Byte Padding to Struct to avoid changing the size of the public configuration struct*/
     uint8_t padding[128
         /* SVT-AV1-HDR additions */
@@ -1104,6 +1119,7 @@ typedef struct EbSvtAv1EncConfiguration {
         - (sizeof(double) * 1)
         - (sizeof(int8_t) * 1)
         - (sizeof(int32_t) * 1)
+        - (sizeof(char *) * 3)
     ];
     // clang-format on
 } EbSvtAv1EncConfiguration;

--- a/Source/App/CMakeLists.txt
+++ b/Source/App/CMakeLists.txt
@@ -15,104 +15,6 @@ cmake_minimum_required(VERSION 3.5...3.28)
 
 # Include Subdirectories
 include_directories(${PROJECT_SOURCE_DIR}/Source/API/)
-find_package(PkgConfig)
-if(NOT PkgConfig_FOUND)
-  message(WARNING "PkgConfig not found; disabled building with dovi & hdr10plus.")
-endif()
-
-option(EXT_LIB_STATIC "Force linking with static libraries for external dependencies" OFF)
-set(SUFFIX "")
-if(EXT_LIB_STATIC)
-  set(SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
-else()
-  set(SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
-endif()
-
-# libdovi detection & preprocessor macro
-option(LIBDOVI_FOUND "Use the dovi library" OFF)
-if(LIBDOVI_FOUND)
-  if(PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_LIBDOVI dovi REQUIRED)
-  endif()
-
-  set(LIBDOVI_LIBRARY_DIR ${PC_LIBDOVI_LIBDIRS})
-
-  set(LIBDOVI_INCLUDE_DIR ${PC_LIBDOVI_INCLUDEDIRS})
-
-  include_directories(${LIBDOVI_INCLUDE_DIR})
-
-  if(EXT_LIB_STATIC OR MSVC)
-    set(LIBDOVI_REQUIRED_LIBRARIES ${PC_LIBDOVI_STATIC_LIBRARIES})
-  else()
-    set(LIBDOVI_REQUIRED_LIBRARIES ${PC_LIBDOVI_LIBRARIES})
-  endif()
-
-  set(LIBDOVI_LIBRARY "")
-  if(WIN32 AND NOT MSVC AND CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT MINGW)
-    # link hack only for native windows and clang
-    # because cmake pass .lib file for windows
-    # but cargo-c produce .dll.lib for shared
-    # and .lib for static library this force passing
-    # .dll extension by creating linker flags
-    foreach(BASE ${LIBDOVI_REQUIRED_LIBRARIES})
-      list(APPEND LIBDOVI_LIBRARY "-l${BASE}${SUFFIX}")
-    endforeach()
-  else()
-    foreach(BASE ${LIBDOVI_REQUIRED_LIBRARIES})
-      list(APPEND LIBDOVI_LIBRARY "${BASE}${SUFFIX}")
-    endforeach()
-  endif()
-
-  add_definitions(-DLIBDOVI_FOUND=1)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with dovi support - Yes\n")
-else()
-  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with dovi support - No\n")
-endif()
-
-# libhdr10plus detection & preprocessor macro
-option(LIBHDR10PLUS_RS_FOUND "Use the hdr10plus library" OFF)
-if(LIBHDR10PLUS_RS_FOUND)
-  if(PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_LIBHDR10PLUS_RS hdr10plus-rs REQUIRED)
-  endif()
-
-  set(LIBHDR10PLUS_RS_LIBRARY_DIR ${PC_LIBHDR10PLUS_RS_LIBDIR})
-
-  set(LIBHDR10PLUS_RS_INCLUDE_DIR ${PC_LIBHDR10PLUS_RS_INCLUDEDIR})
-
-  include_directories(${LIBHDR10PLUS_RS_INCLUDE_DIR})
-
-  if(EXT_LIB_STATIC OR MSVC)
-    set(LIBHDR10PLUS_RS_REQUIRED_LIBRARIES ${PC_LIBHDR10PLUS_RS_STATIC_LIBRARIES})
-  else()
-    set(LIBHDR10PLUS_RS_REQUIRED_LIBRARIES ${PC_LIBHDR10PLUS_RS_LIBRARIES})
-  endif()
-
-  set(LIBHDR10PLUS_RS_LIBRARY "")
-  if(WIN32 AND NOT MSVC AND CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT MINGW)
-    # link hack only for native windows and clang
-    # because cmake pass .lib file for windows
-    # on both static and shared library
-    # but cargo-c produce .dll.lib for shared
-    # and .lib for static library this force passing
-    # .dll extension by creating linker flags
-    if(NOT EXT_LIB_STATIC)
-      message(WARNING "Shared version of hdr10plus-rs library is known to cause error when link")
-    endif()
-    foreach(BASE ${LIBHDR10PLUS_RS_REQUIRED_LIBRARIES})
-      list(APPEND LIBHDR10PLUS_RS_LIBRARY "-l${BASE}${SUFFIX}")
-    endforeach()
-  else()
-    foreach(BASE ${LIBHDR10PLUS_RS_REQUIRED_LIBRARIES})
-      list(APPEND LIBHDR10PLUS_RS_LIBRARY "${BASE}${SUFFIX}")
-    endforeach()
-  endif()
-
-  add_definitions(-DLIBHDR10PLUS_RS_FOUND=1)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with hdr10plus support - Yes\n")
-else()
-  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with hdr10plus support - No\n")
-endif()
 
 set(all_files
     ../API/EbConfigMacros.h
@@ -146,7 +48,6 @@ endif()
 
 #********** SET COMPILE FLAGS************
 # Link the Encoder App
-target_link_libraries(SvtAv1EncApp PRIVATE SvtAv1Enc ${LIBDOVI_LIBRARY} ${LIBHDR10PLUS_RS_LIBRARY})
-target_link_directories(SvtAv1EncApp PRIVATE ${LIBDOVI_LIBRARY_DIR} ${LIBHDR10PLUS_RS_LIBRARY_DIR})
+target_link_libraries(SvtAv1EncApp PRIVATE SvtAv1Enc)
 
 install(TARGETS SvtAv1EncApp RUNTIME COMPONENT Runtime DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Source/App/app_config.c
+++ b/Source/App/app_config.c
@@ -428,43 +428,21 @@ static EbErrorType set_cfg_roi_map_file(EbConfig *cfg, const char *token, const 
 }
 #if CONFIG_ENABLE_FILM_GRAIN
 static EbErrorType set_cfg_fgs_table_path(EbConfig *cfg, const char *token, const char *value) {
-    EbErrorType ret  = EB_ErrorBadParameter;
-    FILE       *file = NULL;
-    if ((ret = open_file(&file, token, value, "r")) < 0)
-        return ret;
-    fclose(file);
-
-    return str_to_str(value, &cfg->fgs_table_path, token);
+    (void)token;
+    return svt_av1_enc_parse_parameter(&cfg->config, "fgs-table", value);
 }
 #endif
 #ifdef LIBDOVI_FOUND
 static EbErrorType set_cfg_dovi_rpu(EbConfig *cfg, const char *token, const char *value) {
-    printf("Svt[info]: Parsing Dolby Vision RPU file...\n");
-    const DoviRpuOpaqueList *rpus = dovi_parse_rpu_bin_file(value);
-    if (rpus->error) {
-        fprintf(stderr, "%s\n", rpus->error);
-        dovi_rpu_list_free(rpus);
-        return validate_error(EB_ErrorBadParameter, token, value);
-    }
-    printf("Svt[info]: Loaded %zu DoVi RPUs\n", rpus->len);
-    cfg->dovi_rpus = rpus;
-    return EB_ErrorNone;
+    (void)token;
+    return svt_av1_enc_parse_parameter(&cfg->config, "dovi", value);
 }
 #endif
 
 #ifdef LIBHDR10PLUS_RS_FOUND
 static EbErrorType set_cfg_hdr10plus_json(EbConfig *cfg, const char *token, const char *value) {
-    printf("Svt[info]: Parsing HDR10+ JSON file...\n");
-    Hdr10PlusRsJsonOpaque *hdr10plus_json = hdr10plus_rs_parse_json(value);
-    const char            *error          = hdr10plus_rs_json_get_error(hdr10plus_json);
-    if (error) {
-        fprintf(stderr, "%s\n", error);
-        hdr10plus_rs_json_free(hdr10plus_json);
-        return validate_error(EB_ErrorBadParameter, token, value);
-    }
-    printf("Svt[info]: Loaded HDR10+ JSON file\n");
-    cfg->hdr10plus_json = hdr10plus_json;
-    return EB_ErrorNone;
+    (void)token;
+    return svt_av1_enc_parse_parameter(&cfg->config, "hdr10plus-json", value);
 }
 #endif
 
@@ -999,10 +977,10 @@ ConfigDescription config_entry_color_description[] = {
      "Set content light level in the format of \"max_cll,max_fall\", refer to the user guide Appendix A.2"},
 // Dolby Vision RPU
 #ifdef LIBDOVI_FOUND
-    {DOLBY_VISION_RPU_TOKEN, "Set the Dolby Vision RPU path"},
+    {DOLBY_VISION_RPU_TOKEN, "Path to Dolby Vision RPU file"},
 #endif
 #ifdef LIBHDR10PLUS_RS_FOUND
-    {HDR10PLUS_JSON_TOKEN, "Set the HDR10+ JSON file path"},
+    {HDR10PLUS_JSON_TOKEN, "Path to HDR10+ metadata JSON file"},
 #endif
     // Termination
     {NULL, NULL}};
@@ -1310,14 +1288,7 @@ EbConfig *svt_config_ctor(bool color) {
     app_cfg->progress            = 1;
     app_cfg->injector_frame_rate = 60;
     app_cfg->roi_map_file        = NULL;
-    app_cfg->fgs_table_path      = NULL;
     app_cfg->mmap.allow          = true;
-#ifdef LIBDOVI_FOUND
-    app_cfg->dovi_rpus = NULL;
-#endif
-#ifdef LIBHDR10PLUS_RS_FOUND
-    app_cfg->hdr10plus_json = NULL;
-#endif
     app_cfg->color = color;
 
     return app_cfg;
@@ -1374,22 +1345,17 @@ void svt_config_dtor(EbConfig *app_cfg) {
     }
 
 #ifdef LIBDOVI_FOUND
-    if (app_cfg->dovi_rpus) {
-        dovi_rpu_list_free(app_cfg->dovi_rpus);
-        app_cfg->dovi_rpus = NULL;
-    }
+    if (app_cfg->config.dovi_rpu_file)
+        free(app_cfg->config.dovi_rpu_file);
 #endif
 #ifdef LIBHDR10PLUS_RS_FOUND
-    if (app_cfg->hdr10plus_json) {
-        hdr10plus_rs_json_free(app_cfg->hdr10plus_json);
-        app_cfg->hdr10plus_json = NULL;
-    }
+    if (app_cfg->config.hdr10plus_json_file)
+        free(app_cfg->config.hdr10plus_json_file);
 #endif
-
-    if (app_cfg->fgs_table_path) {
-        free(app_cfg->fgs_table_path);
-        app_cfg->fgs_table_path = NULL;
-    }
+#if CONFIG_ENABLE_FILM_GRAIN
+    if (app_cfg->config.fgs_table_file)
+        free(app_cfg->config.fgs_table_file);
+#endif
 
     for (size_t i = 0; i < app_cfg->forced_keyframes.count; ++i) free(app_cfg->forced_keyframes.specifiers[i]);
     free(app_cfg->forced_keyframes.specifiers);
@@ -2250,150 +2216,6 @@ static bool warn_legacy_token(const char *const token) {
     return false;
 }
 
-#if CONFIG_ENABLE_FILM_GRAIN
-static EbErrorType read_fgs_table(EbConfig *cfg) {
-    EbErrorType   ret = EB_ErrorBadParameter;
-    AomFilmGrain *film_grain;
-    FILE         *file;
-    FOPEN(file, cfg->fgs_table_path, "r");
-
-    if (!file)
-        return EB_ErrorBadParameter;
-
-    // Read in one extra character as there should be a newline
-    char magic[9];
-    if (!fread(magic, 9, 1, file) || strncmp(magic, "filmgrn1", 8)) {
-        fprintf(stderr, "invalid grain table magic %s\n", cfg->fgs_table_path);
-        fclose(file);
-        return ret;
-    }
-
-    film_grain = (AomFilmGrain *)calloc(1, sizeof(AomFilmGrain));
-
-    while (!feof(file)) {
-        int num_read = fscanf(file,
-                              "E %*d %*d %d %hu %d\n",
-                              &film_grain->apply_grain,
-                              &film_grain->random_seed,
-                              &film_grain->update_parameters);
-
-        if (num_read == 0 && feof(file)) {
-            fprintf(stderr, "invalid grain table %s\n", cfg->fgs_table_path);
-            goto fail;
-        }
-        if (num_read != 3) {
-            fprintf(stderr, "Unable to read entry header. Read %d != 3\n", num_read);
-            goto fail;
-        }
-
-        if (film_grain->update_parameters) {
-            num_read = fscanf(file,
-                              "p %d %d %d %d %d %d %d %d %d %d %d %d\n",
-                              &film_grain->ar_coeff_lag,
-                              &film_grain->ar_coeff_shift,
-                              &film_grain->grain_scale_shift,
-                              &film_grain->scaling_shift,
-                              &film_grain->chroma_scaling_from_luma,
-                              &film_grain->overlap_flag,
-                              &film_grain->cb_mult,
-                              &film_grain->cb_luma_mult,
-                              &film_grain->cb_offset,
-                              &film_grain->cr_mult,
-                              &film_grain->cr_luma_mult,
-                              &film_grain->cr_offset);
-            if (num_read != 12) {
-                fprintf(stderr, "Unable to read entry header. Read %d != 12\n", num_read);
-                goto fail;
-            }
-            if (!fscanf(file, "\tsY %d ", &film_grain->num_y_points)) {
-                fprintf(stderr, "Unable to read num y points\n");
-                goto fail;
-            }
-            for (int i = 0; i < film_grain->num_y_points; ++i) {
-                if (2 !=
-                    fscanf(file, "%d %d", &film_grain->scaling_points_y[i][0], &film_grain->scaling_points_y[i][1])) {
-                    fprintf(stderr, "Unable to read y scaling points\n");
-                    goto fail;
-                }
-            }
-            if (!fscanf(file, "\n\tsCb %d", &film_grain->num_cb_points)) {
-                fprintf(stderr, "Unable to read num cb points\n");
-                goto fail;
-            }
-            for (int i = 0; i < film_grain->num_cb_points; ++i) {
-                if (2 !=
-                    fscanf(file, "%d %d", &film_grain->scaling_points_cb[i][0], &film_grain->scaling_points_cb[i][1])) {
-                    fprintf(stderr, "Unable to read cb scaling points\n");
-                    goto fail;
-                }
-            }
-            if (!fscanf(file, "\n\tsCr %d", &film_grain->num_cr_points)) {
-                fprintf(stderr, "Unable to read num cr points\n");
-                goto fail;
-            }
-            for (int i = 0; i < film_grain->num_cr_points; ++i) {
-                if (2 !=
-                    fscanf(file, "%d %d", &film_grain->scaling_points_cr[i][0], &film_grain->scaling_points_cr[i][1])) {
-                    fprintf(stderr, "Unable to read cr scaling points\n");
-                    goto fail;
-                }
-            }
-
-            if (fscanf(file, "\n\tcY")) {
-                fprintf(stderr, "Unable to read Y coeffs header (cY)\n");
-                goto fail;
-            }
-            const int n = 2 * film_grain->ar_coeff_lag * (film_grain->ar_coeff_lag + 1);
-            for (int i = 0; i < n; ++i) {
-                if (1 != fscanf(file, "%d", &film_grain->ar_coeffs_y[i])) {
-                    fprintf(stderr, "Unable to read Y coeffs\n");
-                    goto fail;
-                }
-            }
-            if (fscanf(file, "\n\tcCb")) {
-                fprintf(stderr, "Unable to read Cb coeffs header (cCb)\n");
-                goto fail;
-            }
-            for (int i = 0; i <= n; ++i) {
-                if (1 != fscanf(file, "%d", &film_grain->ar_coeffs_cb[i])) {
-                    fprintf(stderr, "Unable to read Cb coeffs\n");
-                    goto fail;
-                }
-            }
-            if (fscanf(file, "\n\tcCr")) {
-                fprintf(stderr, "Unable read to Cr coeffs header (cCr)\n");
-                goto fail;
-            }
-            for (int i = 0; i <= n; ++i) {
-                if (1 != fscanf(file, "%d", &film_grain->ar_coeffs_cr[i])) {
-                    fprintf(stderr, "Unable to read Cr coeffs\n");
-                    goto fail;
-                }
-            }
-            if (fscanf(file, "\n")) {
-                // optional newline at end of file,
-            }
-        }
-
-        // TODO Add functionality to read multiple grain table entries
-        break;
-    }
-
-    fclose(file);
-
-    film_grain->apply_grain = 1;
-    film_grain->ignore_ref  = 1;
-    cfg->config.fgs_table   = film_grain;
-
-    return EB_ErrorNone;
-fail:
-    free(film_grain);
-
-    fclose(file);
-    return ret;
-}
-#endif
-
 /******************************************
 * Read Command Line
 ******************************************/
@@ -2506,19 +2328,6 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EncChannel *chan
         }
     }
 
-#if CONFIG_ENABLE_FILM_GRAIN
-    EbConfig *cfg = channel->app_cfg;
-    if (cfg->fgs_table_path) {
-        if (cfg->config.film_grain_denoise_strength > 0) {
-            fprintf(stderr,
-                    "Warning: Both film-grain-denoise and fgs-table were specified\nfilm-grain-denoise will be "
-                    "disabled\n");
-            cfg->config.film_grain_denoise_strength = 0;
-        }
-        channel->return_error = read_fgs_table(cfg);
-        return_error          = (EbErrorType)(return_error & channel->return_error);
-    }
-#endif
     /***************************************************************************************************/
     /**************************************   Verify configuration parameters   ************************/
     /***************************************************************************************************/

--- a/Source/App/app_config.h
+++ b/Source/App/app_config.h
@@ -14,12 +14,6 @@
 
 #include <stdio.h>
 #include <stdbool.h>
-#ifdef LIBDOVI_FOUND
-#include <libdovi/rpu_parser.h>
-#endif
-#ifdef LIBHDR10PLUS_RS_FOUND
-#include <libhdr10plus-rs/hdr10plus.h>
-#endif
 
 #include "EbSvtAv1Enc.h"
 
@@ -193,14 +187,6 @@ typedef struct EbConfig {
 
     FILE         *roi_map_file;
     SvtAv1RoiMap *roi_map;
-#ifdef LIBDOVI_FOUND
-    const DoviRpuOpaqueList *dovi_rpus;
-#endif
-#ifdef LIBHDR10PLUS_RS_FOUND
-    Hdr10PlusRsJsonOpaque *hdr10plus_json;
-#endif
-
-    char *fgs_table_path;
 
     bool color;
 } EbConfig;

--- a/Source/App/app_process_cmd.c
+++ b/Source/App/app_process_cmd.c
@@ -535,46 +535,6 @@ static EbErrorType retrieve_roi_map_event(SvtAv1RoiMap *roi_map, uint64_t pic_nu
     return EB_ErrorNone;
 }
 
-#ifdef LIBDOVI_FOUND
-static EbErrorType retrieve_dovi_rpu_for_frame(const DoviRpuOpaqueList *rpus, uint64_t pic_num,
-                                               EbBufferHeaderType *header_ptr) {
-    if (rpus == NULL) {
-        return EB_ErrorNone;
-    }
-    if (pic_num > rpus->len - 1) {
-        return EB_ErrorNone;
-    }
-    DoviRpuOpaque  *rpu         = rpus->list[pic_num];
-    const DoviData *rpu_payload = dovi_write_av1_rpu_metadata_obu_t35_complete(rpu);
-    if (svt_add_metadata(header_ptr, EB_AV1_METADATA_TYPE_ITUT_T35, rpu_payload->data, rpu_payload->len)) {
-        dovi_data_free(rpu_payload);
-        return EB_ErrorInsufficientResources;
-    }
-    dovi_data_free(rpu_payload);
-    return EB_ErrorNone;
-}
-#endif
-#ifdef LIBHDR10PLUS_RS_FOUND
-static EbErrorType retrieve_hdr10plus_payload_for_frame(Hdr10PlusRsJsonOpaque *hdr10plus_json, uint64_t pic_num,
-                                                        EbBufferHeaderType *header_ptr) {
-    if (hdr10plus_json == NULL) {
-        return EB_ErrorNone;
-    }
-
-    const Hdr10PlusRsData *payload = hdr10plus_rs_write_av1_metadata_obu_t35_complete(hdr10plus_json, pic_num);
-    if (!payload) {
-        return EB_ErrorNone;
-    }
-
-    if (svt_add_metadata(header_ptr, EB_AV1_METADATA_TYPE_ITUT_T35, payload->data, payload->len)) {
-        hdr10plus_rs_data_free(payload);
-        return EB_ErrorInsufficientResources;
-    }
-    hdr10plus_rs_data_free(payload);
-    return EB_ErrorNone;
-}
-#endif
-
 static void free_private_data_list(void *node_head) {
     while (node_head) {
         EbPrivDataNode *node = (EbPrivDataNode *)node_head;
@@ -652,12 +612,6 @@ void process_input_buffer(EncChannel *channel) {
             test_update_psnr_per_frame_info(header_ptr->pts, header_ptr);
 #endif
             retrieve_roi_map_event(app_cfg->roi_map, header_ptr->pts, header_ptr);
-#ifdef LIBDOVI_FOUND
-            retrieve_dovi_rpu_for_frame(app_cfg->dovi_rpus, header_ptr->pts, header_ptr);
-#endif
-#ifdef LIBHDR10PLUS_RS_FOUND
-            retrieve_hdr10plus_payload_for_frame(app_cfg->hdr10plus_json, header_ptr->pts, header_ptr);
-#endif
             // Send the picture
             if (svt_av1_enc_send_picture(component_handle, header_ptr) != EB_ErrorNone)
                 return_value = APP_ExitConditionFinished;

--- a/Source/Lib/CMakeLists.txt
+++ b/Source/Lib/CMakeLists.txt
@@ -121,8 +121,108 @@ set_target_properties(SvtAv1Enc PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 set_target_properties(SvtAv1Enc PROPERTIES C_VISIBILITY_PRESET hidden)
 set_target_properties(SvtAv1Enc PROPERTIES EXPORT_NAME ${SVT_AV1_TARGET})
 
+find_package(PkgConfig)
+if(NOT PkgConfig_FOUND)
+  message(WARNING "PkgConfig not found; disabled building with dovi & hdr10plus.")
+endif()
+
+option(EXT_LIB_STATIC "Force linking with static libraries for external dependencies" OFF)
+set(SUFFIX "")
+if(EXT_LIB_STATIC)
+  set(SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
+else()
+  set(SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+endif()
+
+# libdovi detection & preprocessor macro
+option(LIBDOVI_FOUND "Use the dovi library" OFF)
+if(LIBDOVI_FOUND)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_LIBDOVI dovi REQUIRED)
+  endif()
+  set(LIBDOVI_LIBRARY_DIR ${PC_LIBDOVI_LIBDIR})
+  set(LIBDOVI_INCLUDE_DIR ${PC_LIBDOVI_INCLUDEDIR})
+
+  target_include_directories(SvtAv1Enc PRIVATE ${LIBDOVI_INCLUDE_DIR})
+
+  if(EXT_LIB_STATIC OR MSVC)
+    set(LIBDOVI_REQUIRED_LIBRARIES ${PC_LIBDOVI_STATIC_LIBRARIES})
+  else()
+    set(LIBDOVI_REQUIRED_LIBRARIES ${PC_LIBDOVI_LIBRARIES})
+  endif()
+
+  set(LIBDOVI_LIBRARY "")
+  if(WIN32 AND NOT MSVC AND CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT MINGW)
+    # link hack only for native windows and clang
+    # because cmake pass .lib file for windows
+    # but cargo-c produce .dll.lib for shared
+    # and .lib for static library this force passing
+    # .dll extension by creating linker flags
+    foreach(BASE ${LIBDOVI_REQUIRED_LIBRARIES})
+      list(APPEND LIBDOVI_LIBRARY "-l${BASE}${SUFFIX}")
+    endforeach()
+  else()
+    foreach(BASE ${LIBDOVI_REQUIRED_LIBRARIES})
+      list(APPEND LIBDOVI_LIBRARY "${BASE}${SUFFIX}")
+    endforeach()
+  endif()
+
+  target_compile_definitions(SvtAv1Enc PUBLIC LIBDOVI_FOUND=1)
+  list(APPEND PC_REQUIRES_PRIVATE "dovi")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with dovi support - Yes\n")
+else()
+  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with dovi support - No\n")
+endif()
+
+# libhdr10plus detection & preprocessor macro
+option(LIBHDR10PLUS_RS_FOUND "Use the hdr10plus library" OFF)
+if(LIBHDR10PLUS_RS_FOUND)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_LIBHDR10PLUS_RS hdr10plus-rs REQUIRED)
+  endif()
+  set(LIBHDR10PLUS_RS_LIBRARY_DIR ${PC_LIBHDR10PLUS_RS_LIBDIR})
+  set(LIBHDR10PLUS_RS_INCLUDE_DIR ${PC_LIBHDR10PLUS_RS_INCLUDEDIR})
+
+  target_include_directories(SvtAv1Enc PRIVATE ${LIBHDR10PLUS_RS_INCLUDE_DIR})
+
+  if(EXT_LIB_STATIC OR MSVC)
+    set(LIBHDR10PLUS_RS_REQUIRED_LIBRARIES ${PC_LIBHDR10PLUS_RS_STATIC_LIBRARIES})
+  else()
+    set(LIBHDR10PLUS_RS_REQUIRED_LIBRARIES ${PC_LIBHDR10PLUS_RS_LIBRARIES})
+  endif()
+
+  set(LIBHDR10PLUS_RS_LIBRARY "")
+  if(WIN32 AND NOT MSVC AND CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT MINGW)
+    # link hack only for native windows and clang
+    # because cmake pass .lib file for windows
+    # on both static and shared library
+    # but cargo-c produce .dll.lib for shared
+    # and .lib for static library this force passing
+    # .dll extension by creating linker flags
+    if(NOT EXT_LIB_STATIC)
+      message(WARNING "Shared version of hdr10plus-rs library is known to cause error when link")
+    endif()
+    foreach(BASE ${LIBHDR10PLUS_RS_REQUIRED_LIBRARIES})
+      list(APPEND LIBHDR10PLUS_RS_LIBRARY "-l${BASE}${SUFFIX}")
+    endforeach()
+  else()
+    foreach(BASE ${LIBHDR10PLUS_RS_REQUIRED_LIBRARIES})
+      list(APPEND LIBHDR10PLUS_RS_LIBRARY "${BASE}${SUFFIX}")
+    endforeach()
+  endif()
+
+  target_compile_definitions(SvtAv1Enc PUBLIC LIBHDR10PLUS_RS_FOUND=1)
+  list(APPEND PC_REQUIRES_PRIVATE "hdr10plus-rs")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with hdr10plus support - Yes\n")
+else()
+  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with hdr10plus support - No\n")
+endif()
+
 target_link_libraries(SvtAv1Enc PUBLIC  "$<BUILD_INTERFACE:${PLATFORM_LIBS}>"
-                                PRIVATE "$<INSTALL_INTERFACE:${PLATFORM_LIBS}>")
+                                PRIVATE "$<INSTALL_INTERFACE:${PLATFORM_LIBS}>"
+                                        ${LIBDOVI_LIBRARY}
+                                        ${LIBHDR10PLUS_RS_LIBRARY})
+target_link_directories(SvtAv1Enc PUBLIC ${LIBDOVI_LIBRARY_DIR} ${LIBHDR10PLUS_RS_LIBRARY_DIR})
 
 file(GLOB API_HEADERS ${PROJECT_SOURCE_DIR}/Source/API/*.h)
 set_target_properties(SvtAv1Enc PROPERTIES PUBLIC_HEADER "${API_HEADERS}")

--- a/Source/Lib/Codec/sequence_control_set.h
+++ b/Source/Lib/Codec/sequence_control_set.h
@@ -322,6 +322,12 @@ typedef struct SequenceControlSet {
     bool use_flat_ipp;
     // If true, enables fast anti-alias aware screen detection
     bool fast_aa_aware_screen_detection_mode;
+#ifdef LIBDOVI_FOUND
+    const void *dovi_rpus;
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+    void *hdr10plus_json;
+#endif
 } SequenceControlSet;
 typedef struct EbSequenceControlSetInstance {
     EbDctor             dctor;

--- a/Source/Lib/Globals/enc_handle.c
+++ b/Source/Lib/Globals/enc_handle.c
@@ -58,6 +58,13 @@
 #include "metadata_handle.h"
 #include "noise_generation.h"
 
+#ifdef LIBDOVI_FOUND
+#include <libdovi/rpu_parser.h>
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+#include <libhdr10plus-rs/hdr10plus.h>
+#endif
+
 #include "pack_unpack_c.h"
 #include "enc_mode_config.h"
 
@@ -1240,6 +1247,149 @@ static ONCE_ROUTINE(init_global_tables) {
 }
 DEFINE_ONCE(global_tables_once);
 
+#if CONFIG_ENABLE_FILM_GRAIN
+static EbErrorType read_fgs_table(EbSvtAv1EncConfiguration *config) {
+    EbErrorType   ret = EB_ErrorBadParameter;
+    AomFilmGrain *film_grain;
+    FILE         *file;
+    FOPEN(file, config->fgs_table_file, "r");
+
+    if (!file)
+        return EB_ErrorBadParameter;
+
+    // Read in one extra character as there should be a newline
+    char magic[9];
+    if (!fread(magic, 9, 1, file) || strncmp(magic, "filmgrn1", 8)) {
+        SVT_ERROR("invalid grain table magic %s\n", config->fgs_table_file);
+        fclose(file);
+        return ret;
+    }
+
+    film_grain = (AomFilmGrain *)calloc(1, sizeof(AomFilmGrain));
+
+    while (!feof(file)) {
+        int num_read = fscanf(file,
+                              "E %*d %*d %d %hu %d\n",
+                              &film_grain->apply_grain,
+                              &film_grain->random_seed,
+                              &film_grain->update_parameters);
+
+        if (num_read == 0 && feof(file)) {
+            SVT_ERROR("invalid grain table %s\n", config->fgs_table_file);
+            goto fail;
+        }
+        if (num_read != 3) {
+            SVT_ERROR("Unable to read entry header. Read %d != 3\n", num_read);
+            goto fail;
+        }
+
+        if (film_grain->update_parameters) {
+            num_read = fscanf(file,
+                              "p %d %d %d %d %d %d %d %d %d %d %d %d\n",
+                              &film_grain->ar_coeff_lag,
+                              &film_grain->ar_coeff_shift,
+                              &film_grain->grain_scale_shift,
+                              &film_grain->scaling_shift,
+                              &film_grain->chroma_scaling_from_luma,
+                              &film_grain->overlap_flag,
+                              &film_grain->cb_mult,
+                              &film_grain->cb_luma_mult,
+                              &film_grain->cb_offset,
+                              &film_grain->cr_mult,
+                              &film_grain->cr_luma_mult,
+                              &film_grain->cr_offset);
+            if (num_read != 12) {
+                SVT_ERROR("Unable to read entry header. Read %d != 12\n", num_read);
+                goto fail;
+            }
+            if (!fscanf(file, "\tsY %d ", &film_grain->num_y_points)) {
+                SVT_ERROR("Unable to read num y points\n");
+                goto fail;
+            }
+            for (int i = 0; i < film_grain->num_y_points; ++i) {
+                if (2 !=
+                    fscanf(file, "%d %d", &film_grain->scaling_points_y[i][0], &film_grain->scaling_points_y[i][1])) {
+                    SVT_ERROR("Unable to read y scaling points\n");
+                    goto fail;
+                }
+            }
+            if (!fscanf(file, "\n\tsCb %d", &film_grain->num_cb_points)) {
+                SVT_ERROR("Unable to read num cb points\n");
+                goto fail;
+            }
+            for (int i = 0; i < film_grain->num_cb_points; ++i) {
+                if (2 !=
+                    fscanf(file, "%d %d", &film_grain->scaling_points_cb[i][0], &film_grain->scaling_points_cb[i][1])) {
+                    SVT_ERROR("Unable to read cb scaling points\n");
+                    goto fail;
+                }
+            }
+            if (!fscanf(file, "\n\tsCr %d", &film_grain->num_cr_points)) {
+                SVT_ERROR("Unable to read num cr points\n");
+                goto fail;
+            }
+            for (int i = 0; i < film_grain->num_cr_points; ++i) {
+                if (2 !=
+                    fscanf(file, "%d %d", &film_grain->scaling_points_cr[i][0], &film_grain->scaling_points_cr[i][1])) {
+                    SVT_ERROR("Unable to read cr scaling points\n");
+                    goto fail;
+                }
+            }
+
+            if (fscanf(file, "\n\tcY")) {
+                SVT_ERROR("Unable to read Y coeffs header (cY)\n");
+                goto fail;
+            }
+            const int n = 2 * film_grain->ar_coeff_lag * (film_grain->ar_coeff_lag + 1);
+            for (int i = 0; i < n; ++i) {
+                if (1 != fscanf(file, "%d", (int *)&film_grain->ar_coeffs_y[i])) {
+                    SVT_ERROR("Unable to read Y coeffs\n");
+                    goto fail;
+                }
+            }
+            if (fscanf(file, "\n\tcCb")) {
+                SVT_ERROR("Unable to read Cb coeffs header (cCb)\n");
+                goto fail;
+            }
+            for (int i = 0; i <= n; ++i) {
+                if (1 != fscanf(file, "%d", (int *)&film_grain->ar_coeffs_cb[i])) {
+                    SVT_ERROR("Unable to read Cb coeffs\n");
+                    goto fail;
+                }
+            }
+            if (fscanf(file, "\n\tcCr")) {
+                SVT_ERROR("Unable read to Cr coeffs header (cCr)\n");
+                goto fail;
+            }
+            for (int i = 0; i <= n; ++i) {
+                if (1 != fscanf(file, "%d", (int *)&film_grain->ar_coeffs_cr[i])) {
+                    SVT_ERROR("Unable to read Cr coeffs\n");
+                    goto fail;
+                }
+            }
+            if (fscanf(file, "\n")) {
+                // optional newline at end of file,
+            }
+        }
+        // TODO Add functionality to read multiple grain table entries
+        break;
+    }
+
+    fclose(file);
+
+    film_grain->apply_grain = 1;
+    film_grain->ignore_ref  = 1;
+    config->fgs_table       = film_grain;
+
+    return EB_ErrorNone;
+fail:
+    free(film_grain);
+
+    fclose(file);
+    return ret;
+}
+#endif
+
 /**********************************
 * Initialize Encoder Library
 **********************************/
@@ -1255,6 +1405,55 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
     svt_aom_setup_common_rtcd_internal(scs->static_config.use_cpu_flags);
     svt_aom_setup_rtcd_internal(scs->static_config.use_cpu_flags);
     svt_run_once(&global_tables_once, init_global_tables);
+
+#ifdef LIBDOVI_FOUND
+    if (scs->static_config.dovi_rpu_file != NULL) {
+        SVT_INFO("Svt[info]: Parsing Dolby Vision RPU file: %s\n", scs->static_config.dovi_rpu_file);
+        const DoviRpuOpaqueList *rpus = dovi_parse_rpu_bin_file(scs->static_config.dovi_rpu_file);
+        if (rpus == NULL) {
+            SVT_ERROR("Failed to parse Dolby Vision RPU file: %s\n", scs->static_config.dovi_rpu_file);
+            return EB_ErrorBadParameter;
+        }
+        if (rpus->error) {
+            SVT_ERROR("Svt[error]: %s\n", rpus->error);
+            dovi_rpu_list_free(rpus);
+            return EB_ErrorBadParameter;
+        }
+        SVT_INFO("Svt[info]: Loaded %zu DoVi RPUs\n", rpus->len);
+        scs->dovi_rpus = rpus;
+    } else {
+        scs->dovi_rpus = NULL;
+    }
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+    if (scs->static_config.hdr10plus_json_file != NULL) {
+        SVT_INFO("Svt[info]: Parsing HDR10+ JSON file: %s\n", scs->static_config.hdr10plus_json_file);
+        Hdr10PlusRsJsonOpaque *hdr10plus_json = hdr10plus_rs_parse_json(scs->static_config.hdr10plus_json_file);
+        const char            *error = hdr10plus_rs_json_get_error(hdr10plus_json);
+        if (error) {
+            SVT_ERROR("Svt[error]: %s\n", error);
+            hdr10plus_rs_json_free(hdr10plus_json);
+            return EB_ErrorBadParameter;
+        }
+        SVT_INFO("Svt[info]: Loaded HDR10+ JSON file\n");
+        scs->hdr10plus_json = hdr10plus_json;
+    } else {
+        scs->hdr10plus_json = NULL;
+    }
+#endif
+
+#if CONFIG_ENABLE_FILM_GRAIN
+    if (scs->static_config.fgs_table_file != NULL) {
+        if (scs->static_config.film_grain_denoise_strength > 0) {
+            SVT_WARN("Both film-grain-denoise and fgs-table were specified; film-grain-denoise will be disabled.\n");
+            scs->static_config.film_grain_denoise_strength = 0;
+        }
+        SVT_INFO("Svt[info]: Parsing film grain table file: %s\n", scs->static_config.fgs_table_file);
+        EbErrorType ret = read_fgs_table(&scs->static_config);
+        if (ret != EB_ErrorNone)
+            return ret;
+    }
+#endif
 
     // Per-instance block geometry table allocation
     EB_MALLOC_ARRAY(scs->blk_geom_mds, scs->max_block_cnt);
@@ -2094,6 +2293,25 @@ EB_API EbErrorType svt_av1_enc_deinit(EbComponentType *svt_enc_component) {
     if (handle->scs_instance && handle->scs_instance->scs && handle->scs_instance->scs->blk_geom_mds != NULL) {
         EB_FREE_ARRAY(handle->scs_instance->scs->blk_geom_mds);
     }
+
+#ifdef LIBDOVI_FOUND
+    if (handle->scs_instance && handle->scs_instance->scs && handle->scs_instance->scs->dovi_rpus != NULL) {
+        dovi_rpu_list_free(handle->scs_instance->scs->dovi_rpus);
+        handle->scs_instance->scs->dovi_rpus = NULL;
+    }
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+    if (handle->scs_instance && handle->scs_instance->scs && handle->scs_instance->scs->hdr10plus_json != NULL) {
+        hdr10plus_rs_json_free(handle->scs_instance->scs->hdr10plus_json);
+        handle->scs_instance->scs->hdr10plus_json = NULL;
+    }
+#endif
+#if CONFIG_ENABLE_FILM_GRAIN
+    if (handle->scs_instance && handle->scs_instance->scs && handle->scs_instance->scs->static_config.fgs_table != NULL) {
+        free(handle->scs_instance->scs->static_config.fgs_table);
+        handle->scs_instance->scs->static_config.fgs_table = NULL;
+    }
+#endif
 
     svt_shutdown_process(handle->input_buffer_resource_ptr);
     svt_shutdown_process(handle->input_cmd_resource_ptr);
@@ -4516,6 +4734,9 @@ static void copy_api_from_app(SequenceControlSet *scs, EbSvtAv1EncConfiguration 
 
     // CDEF scaling
     scs->static_config.cdef_scaling = config_struct->cdef_scaling;
+    scs->static_config.dovi_rpu_file = config_struct->dovi_rpu_file;
+    scs->static_config.hdr10plus_json_file = config_struct->hdr10plus_json_file;
+    scs->static_config.fgs_table_file = config_struct->fgs_table_file;
 
     // Override settings for Still IQ tune
     if (scs->static_config.tune == TUNE_IQ) {
@@ -5294,6 +5515,47 @@ static EbErrorType validate_on_the_fly_settings(EbBufferHeaderType *input_ptr, S
     }
     return EB_ErrorNone;
 }
+
+#ifdef LIBDOVI_FOUND
+static EbErrorType retrieve_dovi_rpu_for_frame(const DoviRpuOpaqueList *rpus, uint64_t pic_num,
+                                               EbBufferHeaderType *header_ptr) {
+    if (rpus == NULL) {
+        return EB_ErrorNone;
+    }
+    if (pic_num > rpus->len - 1) {
+        return EB_ErrorNone;
+    }
+    DoviRpuOpaque  *rpu         = rpus->list[pic_num];
+    const DoviData *rpu_payload = dovi_write_av1_rpu_metadata_obu_t35_complete(rpu);
+    if (svt_add_metadata(header_ptr, EB_AV1_METADATA_TYPE_ITUT_T35, rpu_payload->data, rpu_payload->len)) {
+        dovi_data_free(rpu_payload);
+        return EB_ErrorInsufficientResources;
+    }
+    dovi_data_free(rpu_payload);
+    return EB_ErrorNone;
+}
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+static EbErrorType retrieve_hdr10plus_payload_for_frame(Hdr10PlusRsJsonOpaque *hdr10plus_json, uint64_t pic_num,
+                                                        EbBufferHeaderType *header_ptr) {
+    if (hdr10plus_json == NULL) {
+        return EB_ErrorNone;
+    }
+
+    const Hdr10PlusRsData *payload = hdr10plus_rs_write_av1_metadata_obu_t35_complete(hdr10plus_json, pic_num);
+    if (!payload) {
+        return EB_ErrorNone;
+    }
+
+    if (svt_add_metadata(header_ptr, EB_AV1_METADATA_TYPE_ITUT_T35, payload->data, payload->len)) {
+        hdr10plus_rs_data_free(payload);
+        return EB_ErrorInsufficientResources;
+    }
+    hdr10plus_rs_data_free(payload);
+    return EB_ErrorNone;
+}
+#endif
+
 /**********************************
 * Empty This Buffer
 **********************************/
@@ -5395,6 +5657,12 @@ EB_API EbErrorType svt_av1_enc_send_picture(
             0);
     }
 
+#ifdef LIBDOVI_FOUND
+    retrieve_dovi_rpu_for_frame(scs->dovi_rpus, app_hdr->pts, lib_reg_hdr);
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+    retrieve_hdr10plus_payload_for_frame(scs->hdr10plus_json, app_hdr->pts, lib_reg_hdr);
+#endif
 
     //Take a new App-RessCoord command
     EbObjectWrapper *input_cmd_wrp;

--- a/Source/Lib/Globals/enc_settings.c
+++ b/Source/Lib/Globals/enc_settings.c
@@ -1092,6 +1092,9 @@ EbErrorType svt_av1_set_default_params(EbSvtAv1EncConfiguration *config_ptr) {
     config_ptr->complex_hvs                       = 0;
     config_ptr->noise_adaptive_filtering          = 2;
     config_ptr->cdef_scaling                      = 15;
+    config_ptr->dovi_rpu_file                     = NULL;
+    config_ptr->hdr10plus_json_file               = NULL;
+    config_ptr->fgs_table_file                    = NULL;
     return return_error;
 }
 
@@ -2365,6 +2368,45 @@ EB_API EbErrorType svt_av1_enc_parse_parameter(EbSvtAv1EncConfiguration *config_
             return str_to_bool(value, bool_opts[i].out);
         }
     }
+
+#ifdef LIBDOVI_FOUND
+    if (!strcmp(name, "dovi")) {
+        if (config_struct->dovi_rpu_file) {
+            free(config_struct->dovi_rpu_file);
+        }
+        config_struct->dovi_rpu_file = (char *)malloc(strlen(value) + 1);
+        if (config_struct->dovi_rpu_file) {
+            strcpy(config_struct->dovi_rpu_file, value);
+        }
+        return EB_ErrorNone;
+    }
+#endif
+
+#ifdef LIBHDR10PLUS_RS_FOUND
+    if (!strcmp(name, "hdr10plus-json")) {
+        if (config_struct->hdr10plus_json_file) {
+            free(config_struct->hdr10plus_json_file);
+        }
+        config_struct->hdr10plus_json_file = (char *)malloc(strlen(value) + 1);
+        if (config_struct->hdr10plus_json_file) {
+            strcpy(config_struct->hdr10plus_json_file, value);
+        }
+        return EB_ErrorNone;
+    }
+#endif
+
+#if CONFIG_ENABLE_FILM_GRAIN
+    if (!strcmp(name, "fgs-table")) {
+        if (config_struct->fgs_table_file) {
+            free(config_struct->fgs_table_file);
+        }
+        config_struct->fgs_table_file = (char *)malloc(strlen(value) + 1);
+        if (config_struct->fgs_table_file) {
+            strcpy(config_struct->fgs_table_file, value);
+        }
+        return EB_ErrorNone;
+    }
+#endif
 
     return return_error;
 }


### PR DESCRIPTION
Closes #47 

I tested fgs-table in both CLI and FFmpeg, and it is working fine.
As for dovi and hdr10plus, I haven't tested them yet, I guess we should test it before merging this PR.
Any help in testing dovi and hdr10plus is welcome, as I currently don't have an HDR10 or DoVi video on hand to test it.

Also, minor changes:
"Set the Dolby Vision RPU path" -> "Path to Dolby Vision RPU file"
"Set the HDR10+ JSON file path" -> "Path to HDR10+ metadata JSON file"

Edit:
Oh, and if we want to use it in FFmpeg, we need to compile svt-av1-hdr with libdovi and libhdr10plus. If using static linking, we also need to link FFmpeg with libdovi and libhdr10plus. If using dynamic linking, we don’t need to link FFmpeg with those libraries, we just need the shared libraries (dovi.dll and hdr10plus-rs.dll on Windows)