### PR TITLE
Fix severe blocking with >=P8 in high CRFs

### DIFF
--- a/Source/Lib/Codec/enc_mode_config.c
+++ b/Source/Lib/Codec/enc_mode_config.c
@@ -1414,9 +1414,9 @@ static void dlf_level_modulation(PictureControlSet *pcs, uint8_t *default_dlf_le
     if (modulation_mode == 2 || modulation_mode == 3) {
         if (dlf_level > 4) {
             if (pcs->ref_skip_percentage > 95) {
-                dlf_level = dlf_level >= 6 ? 0 : dlf_level + 2;
+                dlf_level = 7;
             } else if (pcs->ref_skip_percentage > 75) {
-                dlf_level = dlf_level == 7 ? 0 : dlf_level + 1;
+                dlf_level = MIN(7, dlf_level + 1);
             }
         }
     }
@@ -1445,7 +1445,7 @@ static uint8_t get_dlf_level(PictureControlSet *pcs, EncMode enc_mode, uint8_t i
                 }
             } else {
                 if (enc_mode <= ENC_M9) {
-                    dlf_level       = 0;
+                    dlf_level       = 7;
                     modulation_mode = 3;
                 } else {
                     dlf_level       = 5;
@@ -1465,10 +1465,10 @@ static uint8_t get_dlf_level(PictureControlSet *pcs, EncMode enc_mode, uint8_t i
             dlf_level       = 6;
             modulation_mode = 3;
         } else if (enc_mode <= ENC_M10) {
-            dlf_level       = is_not_last_layer ? 6 : 0;
+            dlf_level       = is_not_last_layer ? 6 : 7;
             modulation_mode = 3;
         } else {
-            dlf_level       = 0;
+            dlf_level       = 7;
             modulation_mode = 3;
         }
     } else if (rtc_tune) { // RTC Non-FLAT
@@ -1476,10 +1476,10 @@ static uint8_t get_dlf_level(PictureControlSet *pcs, EncMode enc_mode, uint8_t i
             dlf_level       = 6;
             modulation_mode = 3;
         } else if (enc_mode <= ENC_M9) {
-            dlf_level       = is_not_last_layer ? 6 : 0;
+            dlf_level       = is_not_last_layer ? 6 : 7;
             modulation_mode = 3;
         } else {
-            dlf_level       = 0;
+            dlf_level       = 7;
             modulation_mode = 3;
         }
     } else if (fast_decode <= 1 || resolution <= INPUT_SIZE_360p_RANGE) { // fast-decode 0 && fast-decode 1
@@ -1495,16 +1495,13 @@ static uint8_t get_dlf_level(PictureControlSet *pcs, EncMode enc_mode, uint8_t i
             dlf_level       = is_not_last_layer ? 3 : 6;
             modulation_mode = 3;
         } else if (enc_mode <= ENC_M9) {
-            dlf_level       = is_not_last_layer ? 6 : 0;
+            dlf_level       = is_not_last_layer ? 6 : 7;
             modulation_mode = 3;
         } else if (enc_mode <= ENC_M11) {
-            if (pcs->coeff_lvl == HIGH_LVL)
-                dlf_level = is_base ? 6 : 0;
-            else
-                dlf_level = is_base ? 6 : is_not_last_layer ? 7 : 0;
+            dlf_level       = is_base ? 6 : 7;
             modulation_mode = 3;
         } else {
-            dlf_level       = 0;
+            dlf_level       = 7;
             modulation_mode = 3;
         }
     } else { // fast-decode 2
@@ -1514,10 +1511,10 @@ static uint8_t get_dlf_level(PictureControlSet *pcs, EncMode enc_mode, uint8_t i
             dlf_level       = 6;
             modulation_mode = 3;
         } else if (enc_mode <= ENC_M10) {
-            dlf_level       = is_not_last_layer ? 6 : 0;
+            dlf_level       = is_not_last_layer ? 6 : 7;
             modulation_mode = 3;
         } else {
-            dlf_level       = is_not_last_layer ? 7 : 0;
+            dlf_level       = 7;
             modulation_mode = 3;
         }
     }


### PR DESCRIPTION
<img width="1500" height="900" alt="cvvdp_plot" src="https://github.com/user-attachments/assets/5abae9df-e01f-44ee-90c4-2aae9c3261b2" />

Note: this does not fix the blocking that is caused by `lpd1_skip_inter_tx_level` in >=P10 non-RTC or >=P9 RTC

<details>
<summary>Example</summary>
<img width="1920" height="1080" alt="blocky" src="https://github.com/user-attachments/assets/50bfec31-3283-4556-a768-b82eb55463a6" />
<img width="1920" height="1080" alt="dlf_fix" src="https://github.com/user-attachments/assets/3741462a-7797-4329-94fb-566c35049e71" />
</details>
The example here is the CRF 8 encode, the first picture showcasing before the DLF fix, and the second picture showcasing the DLF fix. Well, it's not exactly a fix, as it is unknown why disabling DLF can cause such issues and why enabling it can fix it.