### PR TITLE
fix CONFIG_X86_AVX2_IS_GUARANTEED

### DIFF
--- a/Source/Lib/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Codec/aom_dsp_rtcd.c
@@ -111,7 +111,7 @@
 #define SET_FUNCTIONS_AVX2(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
     do {                                                                                           \
         CHECK_PTR_IS_NOT_SET(ptr)                                                                  \
-        SET_FUNCTIONS_X86(ptr, neon, neon_dotprod, neon_i8mm, sve, sve2)                           \
+        SET_FUNCTIONS_X86(ptr, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)     \
         CHECK_PTR_IS_SET(ptr)                                                                      \
     } while (0)
 #else

--- a/Source/Lib/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Codec/common_dsp_rtcd.c
@@ -384,7 +384,7 @@ EbCpuFlags svt_aom_get_cpu_flags_to_use() { return 0; }
 #define SET_FUNCTIONS_AVX2(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
     do {                                                                                           \
         CHECK_PTR_IS_NOT_SET(ptr)                                                                  \
-        SET_FUNCTIONS_X86(ptr, neon, neon_dotprod, neon_i8mm, sve, sve2)                           \
+        SET_FUNCTIONS_X86(ptr, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)     \
         CHECK_PTR_IS_SET(ptr)                                                                      \
     } while (0)
 #else


### PR DESCRIPTION
On systems where it's applicable binary size gets reduced by ~500 KiB
<img width="282" height="50" alt="image" src="https://github.com/user-attachments/assets/8f73cd04-b478-4644-bb4c-39afc0655b56" />
