### PR TITLE
Fix ABI incompatibility with v4.1.0 due to padding

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -1104,7 +1104,7 @@ typedef struct EbSvtAv1EncConfiguration {
                     sizeof(uint8_t) // pred_strucutre type was changed from uint8_t to PredStructure
                     /* SVT-AV1-HDR additions */
                     - (sizeof(uint8_t) * 10) - (sizeof(int8_t) * 1) - (sizeof(int32_t) * 1) - (sizeof(bool) * 3) -
-                    (sizeof(double))];
+                    (sizeof(double)) - 2 /* implicit alignment padding */];
     // clang-format on
 } EbSvtAv1EncConfiguration;
 


### PR DESCRIPTION
From new findings in the Discord, there are internal padding due to memory alignment
Right now, the size of mainline v4.1.0 is 664 bytes
But svt-av1-hdr exceeds it by 2 bytes, so 666 bytes, but since it needs to be a multiple of 8, it pads to 672
So we subtract 2 to make it 664 bytes, this should fix ABI incompatibility